### PR TITLE
Expose Name

### DIFF
--- a/src/TreeMenu/ValueConverters/ISimpleTreeItem.cs
+++ b/src/TreeMenu/ValueConverters/ISimpleTreeItem.cs
@@ -12,6 +12,7 @@ namespace Our.Umbraco.SimpleTreeMenu
         IPublishedElement Item { get; set; }
         IEnumerable<ISimpleTreeItem> Items { get; set; }
         Guid Key { get; }
+        string Name { get; }
         int Level { get; set; }
         IEnumerable<IPublishedProperty> Properties { get; }
 

--- a/src/TreeMenu/ValueConverters/SimpleTreeItem.cs
+++ b/src/TreeMenu/ValueConverters/SimpleTreeItem.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.SimpleTreeMenu
         public IPublishedContentType ContentType => Item.ContentType;
 
         public Guid Key => Item.Key;
-
+        public string Name { get; set; }
         public IEnumerable<IPublishedProperty> Properties => Item.Properties;
 
         public IPublishedProperty GetProperty(string alias)

--- a/src/TreeMenu/ValueConverters/SimpleTreeMenuConverter.cs
+++ b/src/TreeMenu/ValueConverters/SimpleTreeMenuConverter.cs
@@ -77,7 +77,8 @@ namespace Our.Umbraco.SimpleTreeMenu.ValueConverters
 
                 var item = new SimpleTreeItem()
                 {
-                    Item = element
+                    Item = element,
+                    Name =sourceObject["name"]?.ToObject<string>()
                 };
 
                 var children = sourceObject["items"]?.ToObject<List<JObject>>();


### PR DESCRIPTION
Hi Dennis,
I notice you are using Name field in editor but you are not exposing that anywhere
```
{
  "items": [
    {
      "id": 1,
      "key": "33a23c26-70f1-451b-bd6c-d0993d99b5cf",
      "contentTypeAlias": "menuNode",
      "name": "Recent news",
      "level": 0,
      "properties": {
        "link": []
      }
    },
    {
      "id": 2,
      "key": "80a9f265-1518-46b8-b4e1-dbc018cad0f3",
      "contentTypeAlias": "menuNode",
      "name": "Employees",
      "level": 0,
      "properties": {
        "link": []
      },
      "items": [
        {
          "id": 3,
          "key": "6820a49c-cb87-42cd-afd5-b139419ae13c",
          "contentTypeAlias": "menuNode",
          "name": "Clara",
          "level": 1,
          "properties": {
            "link": []
          },
          "items": [
            {
              "id": 4,
              "key": "82d3a123-0b4c-448f-ad06-92ff6160ddb2",
              "contentTypeAlias": "menuNode",
              "name": "Content Listing",
              "level": 2,
              "properties": {
                "link": []
              }
            }
          ]
        }
      ]
    }
  ]
}
```
I add properties which will expose that via ISimpleTreeItem.